### PR TITLE
feat: add doctrine odm check

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Configurating health check - all available you can see [here](https://github.com
 # config/packages/symfony_health_check.yaml`
 symfony_health_check:
     health_checks:
-        - id: symfony_health_check.doctrine_check
+        - id: symfony_health_check.doctrine_orm_check
     ping_checks:
         - id: symfony_health_check.status_up_check
 ```
@@ -51,7 +51,7 @@ Change response code:
 ```yaml
 symfony_health_check:
     health_checks:
-        - id: symfony_health_check.doctrine_check
+        - id: symfony_health_check.doctrine_orm_check
     ping_checks:
         - id: symfony_health_check.status_up_check
     ping_error_response_code: 500
@@ -116,7 +116,7 @@ Then we add our custom health check to collection
 ```yaml
 symfony_health_check:
     health_checks:
-        - id: symfony_health_check.doctrine_check
+        - id: symfony_health_check.doctrine_orm_check
         - id: custom_health_check // custom service check id
 ```
 

--- a/src/Check/DoctrineODMCheck.php
+++ b/src/Check/DoctrineODMCheck.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SymfonyHealthCheckBundle\Check;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use SymfonyHealthCheckBundle\Dto\Response;
+use Throwable;
+
+class DoctrineODMCheck implements CheckInterface
+{
+    private const CHECK_RESULT_NAME = 'doctrine_odm_check';
+
+    private ContainerInterface $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    public function check(): Response
+    {
+        /**
+         * @var object|null $documentManager
+         */
+        $documentManager = $this->container->get(
+            'doctrine_mongodb.odm.document_manager',
+            ContainerInterface::NULL_ON_INVALID_REFERENCE,
+        );
+
+        if (!$documentManager) {
+            return new Response(self::CHECK_RESULT_NAME, false, 'Document Manager Not Found.');
+        }
+
+        $client = $documentManager->getClient();
+        $databaseName = $documentManager->getConfiguration()->getDefaultDB() ?? 'admin';
+
+        try {
+            $client->selectDatabase($databaseName)->command(['ping' => 1]);
+        } catch (Throwable $e) {
+            return new Response(self::CHECK_RESULT_NAME, false, $e->getMessage());
+        }
+
+        return new Response(self::CHECK_RESULT_NAME, true, 'ok');
+    }
+}

--- a/src/Check/DoctrineORMCheck.php
+++ b/src/Check/DoctrineORMCheck.php
@@ -8,7 +8,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use SymfonyHealthCheckBundle\Dto\Response;
 use Throwable;
 
-class DoctrineCheck implements CheckInterface
+class DoctrineORMCheck implements CheckInterface
 {
     private const CHECK_RESULT_NAME = 'doctrine';
 

--- a/src/Resources/config/health_checks.xml
+++ b/src/Resources/config/health_checks.xml
@@ -5,7 +5,14 @@
     http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <defaults autowire="true" autoconfigure="true" public="true" />
-        <service id="symfony_health_check.doctrine_check" class="SymfonyHealthCheckBundle\Check\DoctrineCheck">
+        <service id="symfony_health_check.doctrine_check" class="SymfonyHealthCheckBundle\Check\DoctrineORMCheck">
+            <argument type="service" id="service_container"/>
+            <deprecated package="macpaw/symfony-health-check-bundle" version="1.4.2">The "%service_id%" service alias is deprecated, use symfony_health_check.doctrine_orm_check instead</deprecated>
+        </service>
+        <service id="symfony_health_check.doctrine_orm_check" class="SymfonyHealthCheckBundle\Check\DoctrineORMCheck">
+            <argument type="service" id="service_container"/>
+        </service>
+        <service id="symfony_health_check.doctrine_odm_check" class="SymfonyHealthCheckBundle\Check\DoctrineODMCheck">
             <argument type="service" id="service_container"/>
         </service>
         <service id="symfony_health_check.environment_check" class="SymfonyHealthCheckBundle\Check\EnvironmentCheck">

--- a/tests/Integration/Controller/HealthControllerTest.php
+++ b/tests/Integration/Controller/HealthControllerTest.php
@@ -6,7 +6,7 @@ namespace SymfonyHealthCheckBundle\Tests\Integration\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use SymfonyHealthCheckBundle\Check\DoctrineCheck;
+use SymfonyHealthCheckBundle\Check\DoctrineORMCheck;
 use SymfonyHealthCheckBundle\Check\EnvironmentCheck;
 use SymfonyHealthCheckBundle\Check\StatusUpCheck;
 use SymfonyHealthCheckBundle\Controller\HealthController;
@@ -62,7 +62,7 @@ class HealthControllerTest extends WebTestCase
     public function testDoctrineCheckServiceNotFoundException(): void
     {
         $healthController = new HealthController();
-        $healthController->addHealthCheck(new DoctrineCheck(new ContainerBuilder()));
+        $healthController->addHealthCheck(new DoctrineORMCheck(new ContainerBuilder()));
 
         $response = $healthController->check();
         self::assertSame(200, $response->getStatusCode());

--- a/tests/Integration/Controller/PingControllerTest.php
+++ b/tests/Integration/Controller/PingControllerTest.php
@@ -6,7 +6,7 @@ namespace SymfonyHealthCheckBundle\Tests\Integration\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use SymfonyHealthCheckBundle\Check\DoctrineCheck;
+use SymfonyHealthCheckBundle\Check\DoctrineORMCheck;
 use SymfonyHealthCheckBundle\Check\EnvironmentCheck;
 use SymfonyHealthCheckBundle\Check\StatusUpCheck;
 use SymfonyHealthCheckBundle\Controller\PingController;
@@ -62,7 +62,7 @@ class PingControllerTest extends WebTestCase
     public function testDoctrineCheckServiceNotFoundException(): void
     {
         $pingController = new PingController();
-        $pingController->addHealthCheck(new DoctrineCheck(new ContainerBuilder()));
+        $pingController->addHealthCheck(new DoctrineORMCheck(new ContainerBuilder()));
 
         $response = $pingController->check();
         self::assertSame(200, $response->getStatusCode());

--- a/tests/Integration/DependencyInjection/SymfonyHealthCheckExtensionTest.php
+++ b/tests/Integration/DependencyInjection/SymfonyHealthCheckExtensionTest.php
@@ -50,10 +50,12 @@ class SymfonyHealthCheckExtensionTest extends TestCase
     {
         $container = $this->createContainerFromFixture('filled_bundle_config');
 
-        self::assertCount(6, $container->getDefinitions());
+        self::assertCount(8, $container->getDefinitions());
         self::assertArrayHasKey(HealthController::class, $container->getDefinitions());
         self::assertArrayHasKey(PingController::class, $container->getDefinitions());
-        self::assertArrayHasKey('symfony_health_check.doctrine_check', $container->getDefinitions());
+        self::assertArrayHasKey('symfony_health_check.doctrine_check', $container->getDefinitions()); #deprecated
+        self::assertArrayHasKey('symfony_health_check.doctrine_orm_check', $container->getDefinitions());
+        self::assertArrayHasKey('symfony_health_check.doctrine_odm_check', $container->getDefinitions());
         self::assertArrayHasKey('symfony_health_check.environment_check', $container->getDefinitions());
         self::assertArrayHasKey('symfony_health_check.status_up_check', $container->getDefinitions());
     }

--- a/tests/Mock/DocumentManager/ClientMock.php
+++ b/tests/Mock/DocumentManager/ClientMock.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SymfonyHealthCheckBundle\Tests\Mock\DocumentManager;
+
+class ClientMock
+{
+    public function selectDatabase(string $databaseName): DatabaseMock
+    {
+        return new DatabaseMock();
+    }
+}

--- a/tests/Mock/DocumentManager/ConfigurationMock.php
+++ b/tests/Mock/DocumentManager/ConfigurationMock.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SymfonyHealthCheckBundle\Tests\Mock\DocumentManager;
+
+class ConfigurationMock
+{
+    public function getDefaultDB(): ?string
+    {
+        return 'default';
+    }
+}

--- a/tests/Mock/DocumentManager/DatabaseMock.php
+++ b/tests/Mock/DocumentManager/DatabaseMock.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SymfonyHealthCheckBundle\Tests\Mock\DocumentManager;
+
+class DatabaseMock
+{
+    public function command(array $command): void
+    {
+    }
+}

--- a/tests/Mock/DocumentManager/DocumentManagerMock.php
+++ b/tests/Mock/DocumentManager/DocumentManagerMock.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SymfonyHealthCheckBundle\Tests\Mock\DocumentManager;
+
+class DocumentManagerMock
+{
+    public function getConfiguration(): ConfigurationMock
+    {
+        return new ConfigurationMock();
+    }
+
+    public function getClient(): ClientMock
+    {
+        return new ClientMock();
+    }
+}

--- a/tests/Unit/Check/DoctrineODMCheckTest.php
+++ b/tests/Unit/Check/DoctrineODMCheckTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SymfonyHealthCheckBundle\Tests\Unit\Check;
+
+use Exception;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use SymfonyHealthCheckBundle\Check\DoctrineODMCheck;
+use SymfonyHealthCheckBundle\Tests\Mock\DocumentManager\ClientMock;
+use SymfonyHealthCheckBundle\Tests\Mock\DocumentManager\ConfigurationMock;
+use SymfonyHealthCheckBundle\Tests\Mock\DocumentManager\DatabaseMock;
+use SymfonyHealthCheckBundle\Tests\Mock\DocumentManager\DocumentManagerMock;
+
+class DoctrineODMCheckTest extends TestCase
+{
+    public function testDoctrineODMHasNotFoundException(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+
+        $container
+            ->method('get')
+            ->with('doctrine_mongodb.odm.document_manager')
+            ->willReturn(null);
+
+        $doctrine = new DoctrineODMCheck($container);
+
+        $result = $doctrine->check()->toArray();
+
+        self::assertIsArray($result);
+        self::assertNotEmpty($result);
+
+        self::assertArrayHasKey('name', $result);
+        self::assertArrayHasKey('result', $result);
+        self::assertArrayHasKey('message', $result);
+        self::assertArrayHasKey('params', $result);
+
+        self::assertSame('doctrine_odm_check', $result['name']);
+        self::assertFalse($result['result']);
+        self::assertSame('Document Manager Not Found.', $result['message']);
+        self::assertIsArray($result['params']);
+    }
+
+    public function testDoctrineODMGetNotFoundException(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+
+        $container
+            ->method('get')
+            ->with('doctrine_mongodb.odm.document_manager')
+            ->willReturn(null);
+
+        $doctrine = new DoctrineODMCheck($container);
+
+        $result = $doctrine->check()->toArray();
+
+        self::assertIsArray($result);
+        self::assertNotEmpty($result);
+
+        self::assertArrayHasKey('name', $result);
+        self::assertArrayHasKey('result', $result);
+        self::assertArrayHasKey('message', $result);
+        self::assertArrayHasKey('params', $result);
+
+        self::assertSame('doctrine_odm_check', $result['name']);
+        self::assertFalse($result['result']);
+        self::assertSame('Document Manager Not Found.', $result['message']);
+        self::assertIsArray($result['params']);
+    }
+
+    public function testDoctrineODMSuccess(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $documentManager = $this->createMock(DocumentManagerMock::class);
+
+        $container
+            ->method('get')
+            ->with('doctrine_mongodb.odm.document_manager')
+            ->willReturn($documentManager);
+
+        $doctrine = new DoctrineODMCheck($container);
+
+        $result = $doctrine->check()->toArray();
+
+        self::assertIsArray($result);
+        self::assertNotEmpty($result);
+
+        self::assertArrayHasKey('name', $result);
+        self::assertArrayHasKey('result', $result);
+        self::assertArrayHasKey('message', $result);
+        self::assertArrayHasKey('params', $result);
+
+        self::assertSame('doctrine_odm_check', $result['name']);
+        self::assertTrue($result['result']);
+        self::assertSame('ok', $result['message']);
+        self::assertIsArray($result['params']);
+    }
+
+    public function testDoctrineFailPing(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $documentManager = $this->createMock(DocumentManagerMock::class);
+        $client = $this->createMock(ClientMock::class);
+        $database = $this->createMock(DatabaseMock::class);
+        $configuration = $this->createMock(ConfigurationMock::class);
+
+        $configuration
+            ->method('getDefaultDB')
+            ->willReturn('default');
+
+        $documentManager
+            ->method('getClient')
+            ->with()
+            ->willReturn($client);
+
+        $documentManager
+            ->method('getConfiguration')
+            ->with()
+            ->willReturn($configuration);
+
+        $client
+            ->method('selectDatabase')
+            ->with('default')
+            ->willReturn($database);
+
+        $database
+            ->method('command')
+            ->with(['ping' => 1])
+            ->will(self::throwException(new Exception('No suitable servers found')));
+
+        $container
+            ->method('get')
+            ->with('doctrine_mongodb.odm.document_manager')
+            ->willReturn($documentManager);
+
+        $doctrine = new DoctrineODMCheck($container);
+
+        $result = $doctrine->check()->toArray();
+
+        self::assertIsArray($result);
+        self::assertNotEmpty($result);
+
+        self::assertArrayHasKey('name', $result);
+        self::assertArrayHasKey('result', $result);
+        self::assertArrayHasKey('message', $result);
+        self::assertArrayHasKey('params', $result);
+
+        self::assertSame('doctrine_odm_check', $result['name']);
+        self::assertFalse($result['result']);
+        self::assertSame('No suitable servers found', $result['message']);
+        self::assertIsArray($result['params']);
+    }
+}

--- a/tests/Unit/Check/DoctrineORMCheckTest.php
+++ b/tests/Unit/Check/DoctrineORMCheckTest.php
@@ -7,13 +7,13 @@ namespace SymfonyHealthCheckBundle\Tests\Unit\Check;
 use Exception;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use SymfonyHealthCheckBundle\Check\DoctrineCheck;
+use SymfonyHealthCheckBundle\Check\DoctrineORMCheck;
 use SymfonyHealthCheckBundle\Tests\Mock\ConnectionMock;
 use SymfonyHealthCheckBundle\Tests\Mock\EntityManagerMock;
 
-class DoctrineCheckTest extends TestCase
+class DoctrineORMCheckTest extends TestCase
 {
-    public function testDoctrineHasNotFoundException(): void
+    public function testDoctrineORMHasNotFoundException(): void
     {
         $container = $this->createMock(ContainerInterface::class);
 
@@ -22,7 +22,7 @@ class DoctrineCheckTest extends TestCase
             ->with('doctrine.orm.entity_manager')
             ->willReturn(false);
 
-        $doctrine = new DoctrineCheck($container);
+        $doctrine = new DoctrineORMCheck($container);
 
         $result = $doctrine->check()->toArray();
 
@@ -40,7 +40,7 @@ class DoctrineCheckTest extends TestCase
         self::assertIsArray($result['params']);
     }
 
-    public function testDoctrineGetNotFoundException(): void
+    public function testDoctrineORMGetNotFoundException(): void
     {
         $container = $this->createMock(ContainerInterface::class);
 
@@ -54,7 +54,7 @@ class DoctrineCheckTest extends TestCase
             ->with('doctrine.orm.entity_manager')
             ->willReturn(null);
 
-        $doctrine = new DoctrineCheck($container);
+        $doctrine = new DoctrineORMCheck($container);
 
         $result = $doctrine->check()->toArray();
 
@@ -72,7 +72,7 @@ class DoctrineCheckTest extends TestCase
         self::assertIsArray($result['params']);
     }
 
-    public function testDoctrineSuccess(): void
+    public function testDoctrineORMSuccess(): void
     {
         $container = $this->createMock(ContainerInterface::class);
         $entityManager = $this->createMock(EntityManagerMock::class);
@@ -87,7 +87,7 @@ class DoctrineCheckTest extends TestCase
             ->with('doctrine.orm.entity_manager')
             ->willReturn($entityManager);
 
-        $doctrine = new DoctrineCheck($container);
+        $doctrine = new DoctrineORMCheck($container);
 
         $result = $doctrine->check()->toArray();
 
@@ -105,7 +105,7 @@ class DoctrineCheckTest extends TestCase
         self::assertIsArray($result['params']);
     }
 
-    public function testDoctrineFailPing(): void
+    public function testDoctrineORMFailPing(): void
     {
         $container = $this->createMock(ContainerInterface::class);
         $entityManager = $this->createMock(EntityManagerMock::class);
@@ -131,7 +131,7 @@ class DoctrineCheckTest extends TestCase
             ->with('doctrine.orm.entity_manager')
             ->willReturn($entityManager);
 
-        $doctrine = new DoctrineCheck($container);
+        $doctrine = new DoctrineORMCheck($container);
 
         $result = $doctrine->check()->toArray();
 


### PR DESCRIPTION
### Why?
The purpose of this PR - to add doctrine odm check

### What?
- added new odm check (alias is symfony_health_check.doctrine_odm_check)
- renamed alias of orm check to symfony_health_check.doctrine_orm_check, deprecated old one
- added test coverage