### PR TITLE
Drop unsupported versions of PHP and Symfony and update development dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,33 +11,38 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php:
-                    - '8.1'
-                    - '8.2'
-                coverage: ['none']
-                symfony-versions:
-                    - '4.4.*'
-                    - '5.4.*'
-                    - '6.0.*'
-                    - '6.1.*'
-                    - '6.2.*'
                 include:
-                    - php: '7.4'
-                      symfony-versions: '^4.4'
+                  # --- Symfony 6.4 LTS ---
+                    - php: '8.1'
+                      symfony-versions: '^6.4'
                       coverage: 'none'
-                    - php: '7.4'
-                      symfony-versions: '^5.4'
+                    - php: '8.2'
+                      symfony-versions: '^6.4'
                       coverage: 'none'
-                    - php: '8.0'
-                      symfony-versions: '^5.4'
+                    - php: '8.3'
+                      symfony-versions: '^6.4'
                       coverage: 'none'
-                    - php: '8.0'
-                      symfony-versions: '^6.0'
+                    - php: '8.4'
+                      symfony-versions: '^6.4'
+                      coverage: 'none'
+                    - php: '8.5'
+                      symfony-versions: '^6.4'
+                      coverage: 'none'
+
+                    # --- Symfony 7.4 LTS ---
+                    - php: '8.2'
+                      symfony-versions: '^7.4'
+                      coverage: 'none'
+                    - php: '8.3'
+                      symfony-versions: '^7.4'
+                      coverage: 'none'
+                    - php: '8.4'
+                      symfony-versions: '^7.4'
                       coverage: 'none'
                     - description: 'Log Code Coverage'
-                      php: '8.2'
+                      php: '8.5'
                       coverage: 'xdebug'
-                      symfony-versions: '^7.0'
+                      symfony-versions: '^7.4'
 
         name: PHP ${{ matrix.php }} Symfony ${{ matrix.symfony-versions }} ${{ matrix.description }}
         steps:

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -36,7 +36,7 @@ jobs:
               run: composer install --no-progress --no-interaction --prefer-dist
 
             - name: Run script
-              run: vendor/bin/phpstan analyse
+              run: vendor/bin/phpstan analyse --memory-limit=1G
 
     composer-validate:
         name: Composer validate

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,6 @@
         "symfony/framework-bundle": "^6.4 || ^7.4"
     },
     "require-dev": {
-        "ext-json": "*",
         "phpstan/phpstan": "^2.1",
         "squizlabs/php_codesniffer": "^4.0",
         "phpunit/phpunit": "^10.5",

--- a/composer.json
+++ b/composer.json
@@ -36,8 +36,7 @@
         "ext-json": "*",
         "phpstan/phpstan": "1.11.*",
         "squizlabs/php_codesniffer": "3.7.*",
-        "symfony/phpunit-bridge": "^3.4 || ^4.1.12 || ^5.0 || ^6.0 || ^7.0",
-        "phpunit/phpunit": "^8.5 || ^9.0",
+        "phpunit/phpunit": "^10.5",
         "symfony/yaml": "^6.4 || ^7.4",
         "symfony/browser-kit": "^6.4 || ^7.4",
         "symfony/cache": "^6.4 || ^7.4",
@@ -67,7 +66,7 @@
             "vendor/bin/phpstan analyse"
         ],
         "phpunit": [
-            "vendor/bin/simple-phpunit"
+            "vendor/bin/phpunit"
         ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "require-dev": {
         "ext-json": "*",
-        "phpstan/phpstan": "1.11.*",
+        "phpstan/phpstan": "^2.1",
         "squizlabs/php_codesniffer": "3.7.*",
         "phpunit/phpunit": "^10.5",
         "symfony/yaml": "^6.4 || ^7.4",
@@ -63,7 +63,7 @@
             "vendor/bin/phpcbf"
         ],
         "phpstan": [
-            "vendor/bin/phpstan analyse"
+            "vendor/bin/phpstan analyse --memory-limit=1G"
         ],
         "phpunit": [
             "vendor/bin/phpunit"

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "require-dev": {
         "ext-json": "*",
         "phpstan/phpstan": "^2.1",
-        "squizlabs/php_codesniffer": "3.7.*",
+        "squizlabs/php_codesniffer": "^4.0",
         "phpunit/phpunit": "^10.5",
         "symfony/yaml": "^6.4 || ^7.4",
         "symfony/browser-kit": "^6.4 || ^7.4",

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "symfony/yaml": "^6.4 || ^7.4",
         "symfony/browser-kit": "^6.4 || ^7.4",
         "symfony/cache": "^6.4 || ^7.4",
-        "predis/predis": "^2.3"
+        "predis/predis": "^3.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,8 @@
         }
     ],
     "require": {
-        "php": ">=7.4",
-        "symfony/framework-bundle": "^3.4 || ^4.1.12 || ^5.0 || ^6.0 || ^7.0"
+        "php": "^8.1",
+        "symfony/framework-bundle": "^6.4 || ^7.4"
     },
     "require-dev": {
         "ext-json": "*",
@@ -38,9 +38,9 @@
         "squizlabs/php_codesniffer": "3.7.*",
         "symfony/phpunit-bridge": "^3.4 || ^4.1.12 || ^5.0 || ^6.0 || ^7.0",
         "phpunit/phpunit": "^8.5 || ^9.0",
-        "symfony/yaml": "^3.4 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
-        "symfony/browser-kit": "^3.4 || ^4.4 || ^5.0 || ^6.0 || ^7.0",
-        "symfony/cache": "^3.4 || ^4.4 || ^5.0 || ^6.0 || ^7.0",
+        "symfony/yaml": "^6.4 || ^7.4",
+        "symfony/browser-kit": "^6.4 || ^7.4",
+        "symfony/cache": "^6.4 || ^7.4",
         "predis/predis": "^2.3"
     },
     "autoload": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -23,7 +23,19 @@
 
     <rule ref="Generic.PHP.ForbiddenFunctions">
         <properties>
-            <property name="forbiddenFunctions" type="array" value="eval=>NULL,dd=>NULL,die=>NULL,var_dump=>NULL,dump=>NULL,sizeof=>count,delete=>unset,print=>echo,echo=>NULL,print_r=>NULL,create_function=>NULL"/>
+            <property name="forbiddenFunctions" type="array">
+                <element key="create_function" value="NULL"/>
+                <element key="dd" value="NULL"/>
+                <element key="delete" value="unset"/>
+                <element key="die" value="NULL"/>
+                <element key="dump" value="NULL"/>
+                <element key="echo" value="NULL"/>
+                <element key="eval" value="NULL"/>
+                <element key="print_r" value="NULL"/>
+                <element key="print" value="echo"/>
+                <element key="sizeof" value="count"/>
+                <element key="var_dump" value="NULL"/>
+            </property>
         </properties>
     </rule>
     <rule ref="Squiz.WhiteSpace.FunctionSpacing">

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,37 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
-        bootstrap="vendor/autoload.php"
-        cacheResult="false"
-        beStrictAboutOutputDuringTests="true"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         cacheResult="false"
+         beStrictAboutOutputDuringTests="true"
 >
-  <coverage>
-    <include>
-      <directory>./src</directory>
-    </include>
-    <report>
-      <clover outputFile="clover.xml"/>
-    </report>
-  </coverage>
   <php>
     <ini name="error_reporting" value="-1"/>
     <ini name="memory_limit" value="-1"/>
     <server name="APP_ENV" value="testing" force="true"/>
     <server name="APP_DEBUG" value="0" force="true"/>
     <server name="SHELL_VERBOSITY" value="-1"/>
-    <server name="SYMFONY_PHPUNIT_REMOVE" value=""/>
-    <server name="SYMFONY_PHPUNIT_VERSION" value="9"/>
-    <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled" />
-    <env name="KERNEL_CLASS" value="SymfonyHealthCheckBundle\Tests\TestKernel" />
+    <env name="KERNEL_CLASS" value="SymfonyHealthCheckBundle\Tests\TestKernel"/>
   </php>
   <testsuites>
     <testsuite name="Symfony Health Check Bundle Test Suite">
       <directory>tests</directory>
     </testsuite>
   </testsuites>
-  <listeners>
-    <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-  </listeners>
-  <logging/>
+  <source>
+    <include>
+      <directory>./src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/Check/RedisCheck.php
+++ b/src/Check/RedisCheck.php
@@ -89,8 +89,6 @@ class RedisCheck implements CheckInterface
             return $response;
         }
 
-        // invalid configuration, RedisClient have different response, than one, provided by RedisArray in fact.
-        // @phpstan-ignore-next-line
         foreach ($response as $pingResult) {
             if (is_bool($pingResult)) {
                 continue;

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -15,11 +15,7 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('symfony_health_check');
 
-        /** @var ArrayNodeDefinition<TreeBuilder> $root */
-        $root = method_exists(TreeBuilder::class, 'getRootNode')
-            ? $treeBuilder->getRootNode()
-            // @phpstan-ignore-next-line - BC layer for Symfony <4.2
-            : $treeBuilder->root('symfony_health_check');
+        $root = $treeBuilder->getRootNode();
 
         $root
             ->children()


### PR DESCRIPTION
This pull request is a follow up to https://github.com/MacPaw/symfony-health-check-bundle/pull/84 and a preparation for https://github.com/MacPaw/symfony-health-check-bundle/issues/85.

The pull request will limit the supported versions of Symfony to the maintained LTS versions 6.4 and 7.4. [The support for 7.3 will be dropped in January 2026.](https://symfony.com/releases/7.3)

This pull request will also drop the development dependency `symfony/phpunit-bride` and replaces it with `PHPUnit 10.5` according to the minimum supported version of `PHP` (8.1), as recommended following this [issue](https://github.com/symfony/symfony/issues/59253) and this [pull request](https://github.com/symfony/demo/pull/1549).

This pull request will also bump the development dependencies `predis/predis`, `phpstan/phpstan`, and `squizlabs/php_codesniffer` to their latest versions and will drop the non required dev dependency `ext-json`.