### PR TITLE
Add .gitattributes to exclude dev files from dist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Export ignore (excluded from Composer packages)
+/.github/              export-ignore
+/tests/                export-ignore
+/.gitattributes        export-ignore
+/.gitignore            export-ignore
+/phpcs.xml.dist        export-ignore
+/phpstan.neon          export-ignore
+/phpunit.xml.dist      export-ignore


### PR DESCRIPTION
This PR adds a .gitattributes file to reduce the package size when installed via Composer with `--prefer-dist`.

The following files and directories are now excluded from the distribution archive:

- .github/ - CI workflows and templates
- tests/ - test suite
- .gitattributes, .gitignore - git configuration
- phpcs.xml.dist, phpstan.neon, phpunit.xml.dist - QA tools configuration