### PR TITLE
Allow predis/predis ^2.2 for RedisCheck development and downstream installs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "symfony/yaml": "^6.4 || ^7.4 || ^8.0",
         "symfony/browser-kit": "^6.4 || ^7.4 || ^8.0",
         "symfony/cache": "^6.4 || ^7.4 || ^8.0",
-        "predis/predis": "^3.3",
+        "predis/predis": "^2.2 || ^3.3",
         "doctrine/mongodb-odm-bundle": "^4.4 || ^5.0",
         "doctrine/orm": "^2.0 || ^3.0"
     },

--- a/src/Check/RedisCheck.php
+++ b/src/Check/RedisCheck.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SymfonyHealthCheckBundle\Check;
 
 use Predis\ClientInterface as PredisClientInterface;
+use Predis\Response\Status as PredisStatusResponse;
 use SymfonyHealthCheckBundle\Adapter\RedisAdapterWrapper;
 use SymfonyHealthCheckBundle\Dto\Response;
 
@@ -60,14 +61,21 @@ class RedisCheck implements CheckInterface
 
     private function checkForPredisClient(PredisClientInterface $client): bool
     {
-        /** @var string|bool $response */
         $response = $client->ping();
 
         if (is_bool($response)) {
             return $response;
         }
 
-        return $this->isValidPingResponse($response);
+        if ($response instanceof PredisStatusResponse) {
+            return $this->isValidPingResponse($response->getPayload());
+        }
+
+        if (is_string($response)) {
+            return $this->isValidPingResponse($response);
+        }
+
+        return false;
     }
 
     private function checkForRedisArrayClient(\RedisArray $client): bool

--- a/tests/Unit/Check/RedisCheckTest.php
+++ b/tests/Unit/Check/RedisCheckTest.php
@@ -331,6 +331,110 @@ class RedisCheckTest extends TestCase
         self::assertSame('Redis ping failed.', $result['message']);
     }
 
+    public function testItFailsCheckWhenPredisPingReturnsFalse(): void
+    {
+        /** @var \Predis\Client $connectionMock */
+        $connectionMock = $this->getMockBuilder(\Predis\Client::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $connectionMock->expects($this->once())
+            ->method('__call')
+            ->with('ping')
+            ->willReturn(false);
+
+        $adapter = $this->createMock(RedisAdapterWrapper::class);
+        $adapter
+            ->method('createConnection')
+            ->willReturn($connectionMock);
+
+        $check = new RedisCheck($adapter, 'redis://localhost');
+
+        $result = $check->check()->toArray();
+
+        self::assertSame('redis_check', $result['name']);
+        self::assertFalse($result['result']);
+        self::assertSame('Redis ping failed.', $result['message']);
+    }
+
+    public function testItFailsCheckWhenPredisPingReturnsInvalidString(): void
+    {
+        /** @var \Predis\Client $connectionMock */
+        $connectionMock = $this->getMockBuilder(\Predis\Client::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $connectionMock->expects($this->once())
+            ->method('__call')
+            ->with('ping')
+            ->willReturn('not-a-pong');
+
+        $adapter = $this->createMock(RedisAdapterWrapper::class);
+        $adapter
+            ->method('createConnection')
+            ->willReturn($connectionMock);
+
+        $check = new RedisCheck($adapter, 'redis://localhost');
+
+        $result = $check->check()->toArray();
+
+        self::assertSame('redis_check', $result['name']);
+        self::assertFalse($result['result']);
+        self::assertSame('Redis ping failed.', $result['message']);
+    }
+
+    public function testItFailsCheckWhenPredisPingReturnsUnsupportedType(): void
+    {
+        /** @var \Predis\Client $connectionMock */
+        $connectionMock = $this->getMockBuilder(\Predis\Client::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $connectionMock->expects($this->once())
+            ->method('__call')
+            ->with('ping')
+            ->willReturn(0);
+
+        $adapter = $this->createMock(RedisAdapterWrapper::class);
+        $adapter
+            ->method('createConnection')
+            ->willReturn($connectionMock);
+
+        $check = new RedisCheck($adapter, 'redis://localhost');
+
+        $result = $check->check()->toArray();
+
+        self::assertSame('redis_check', $result['name']);
+        self::assertFalse($result['result']);
+        self::assertSame('Redis ping failed.', $result['message']);
+    }
+
+    public function testItSuccessCheckWithPredisClientWhenPingReturnsPlusPongStatus(): void
+    {
+        /** @var \Predis\Client $connectionMock */
+        $connectionMock = $this->getMockBuilder(\Predis\Client::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $connectionMock->expects($this->once())
+            ->method('__call')
+            ->with('ping')
+            ->willReturn(PredisStatusResponse::get('+PONG'));
+
+        $adapter = $this->createMock(RedisAdapterWrapper::class);
+        $adapter
+            ->method('createConnection')
+            ->willReturn($connectionMock);
+
+        $check = new RedisCheck($adapter, 'redis://localhost');
+
+        $result = $check->check()->toArray();
+
+        self::assertSame('redis_check', $result['name']);
+        self::assertTrue($result['result']);
+        self::assertSame('ok', $result['message']);
+    }
+
     public static function provideAvailablePingResponsesOnDefaultClients(): array
     {
         return [

--- a/tests/Unit/Check/RedisCheckTest.php
+++ b/tests/Unit/Check/RedisCheckTest.php
@@ -6,6 +6,7 @@ namespace SymfonyHealthCheckBundle\Tests\Unit\Check;
 
 use PHPUnit\Framework\TestCase;
 use Predis\Connection\Cluster\RedisCluster;
+use Predis\Response\Status as PredisStatusResponse;
 use SymfonyHealthCheckBundle\Adapter\RedisAdapterWrapper;
 use SymfonyHealthCheckBundle\Check\RedisCheck;
 
@@ -276,6 +277,58 @@ class RedisCheckTest extends TestCase
         self::assertTrue($result['result']);
         self::assertSame('ok', $result['message']);
         self::assertIsArray($result['params']);
+    }
+
+    public function testItSuccessCheckWithPredisClientWhenPingReturnsStatusObject(): void
+    {
+        /** @var \Predis\Client $connectionMock */
+        $connectionMock = $this->getMockBuilder(\Predis\Client::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $connectionMock->expects($this->once())
+            ->method('__call')
+            ->with('ping')
+            ->willReturn(PredisStatusResponse::get('PONG'));
+
+        $adapter = $this->createMock(RedisAdapterWrapper::class);
+        $adapter
+            ->method('createConnection')
+            ->willReturn($connectionMock);
+
+        $check = new RedisCheck($adapter, 'redis://localhost');
+
+        $result = $check->check()->toArray();
+
+        self::assertSame('redis_check', $result['name']);
+        self::assertTrue($result['result']);
+        self::assertSame('ok', $result['message']);
+    }
+
+    public function testItFailsCheckWhenPredisPingReturnsNonPongStatus(): void
+    {
+        /** @var \Predis\Client $connectionMock */
+        $connectionMock = $this->getMockBuilder(\Predis\Client::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $connectionMock->expects($this->once())
+            ->method('__call')
+            ->with('ping')
+            ->willReturn(PredisStatusResponse::get('unexpected'));
+
+        $adapter = $this->createMock(RedisAdapterWrapper::class);
+        $adapter
+            ->method('createConnection')
+            ->willReturn($connectionMock);
+
+        $check = new RedisCheck($adapter, 'redis://localhost');
+
+        $result = $check->check()->toArray();
+
+        self::assertSame('redis_check', $result['name']);
+        self::assertFalse($result['result']);
+        self::assertSame('Redis ping failed.', $result['message']);
     }
 
     public static function provideAvailablePingResponsesOnDefaultClients(): array


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Composer:** `require-dev` `predis/predis` is `^2.2 || ^3.3` so projects on Predis 2 can use the bundle.
- **RedisCheck:** Real Predis `ping()` returns `Predis\Response\Status` (e.g. `PONG`), not a raw string. With `strict_types`, passing that into `isValidPingResponse(string $response)` caused a **TypeError**. The check now uses `getPayload()` for `Status` and only passes strings into `isValidPingResponse`.
- **Tests:** Predis path coverage includes string/bool/Status success and failure, `false`, invalid string, unsupported ping return type, and `Status` with `+PONG`.

## Verification

- PHPStan level 9: clean
- PHPUnit: 58 tests
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-038b6766-72ea-40e4-9448-23aceb05fad1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-038b6766-72ea-40e4-9448-23aceb05fad1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

